### PR TITLE
Added Explicit Proxy Flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Usage of ./sourcemapper:
 Sourcemapper will download or read the map file at `url`, and then spit the sources out into the directory defined by `output`.
 
 ```None
-doi@asov:~$ ./sourcemapper -o dhubsrc -u https://hub.docker.com/public/js/client.356c14916fb23f85707f.js.map
+doi@asov:~$ ./sourcemapper -output dhubsrc -url https://hub.docker.com/public/js/client.356c14916fb23f85707f.js.map
 [+] Retriving Sourcemap from https://hub.docker.com/public/js/client.356c14916fb23f85707f.js.map
 [+] Read 23045027 bytes, parsing JSON
 [+] Retrieved Sourcemap with version 3, containing 1828 entries

--- a/main.go
+++ b/main.go
@@ -69,25 +69,17 @@ func getSourceMap(source string, headers []string, insecureTLS bool, proxyURL ur
 		tr := &http.Transport{}
 
 		if insecureTLS {
-			tr := &http.Transport{
+			tr = &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}
-			if proxyURL != (url.URL{}) {
-				tr.Proxy = http.ProxyURL(&proxyURL)
-			}
 
+		}
+		if proxyURL != (url.URL{}) {
 			tr.Proxy = http.ProxyURL(&proxyURL)
-			client = http.Client{
-				Transport: tr,
-			}
-		} else {
+		}
 
-			if proxyURL != (url.URL{}) {
-				tr.Proxy = http.ProxyURL(&proxyURL)
-			}
-			client = http.Client{
-				Transport: tr,
-			}
+		client = http.Client{
+			Transport: tr,
 		}
 
 		if len(headers) > 0 {
@@ -165,7 +157,7 @@ func main() {
 
 	outDir := flag.String("output", "", "Source file output directory - REQUIRED")
 	urlflag := flag.String("url", "", "URL or path to the Sourcemap file - REQUIRED")
-	proxy := flag.String("proxy", "", "Explicity HTTP client proxy")
+	proxy := flag.String("proxy", "", "Proxy URL")
 	help := flag.Bool("help", false, "Show help")
 	insecure := flag.Bool("insecure", false, "Ignore invalid TLS certificates")
 	flag.Var(&headers, "header", "A header to send with the request, similar to curl's -H. Can be set multiple times, EG: \"./sourcemapper --header \"Cookie: session=bar\" --header \"Authorization: blerp\"")
@@ -178,7 +170,7 @@ func main() {
 	if *proxy != "" {
 		p, err := url.Parse(*proxy)
 		if err != nil {
-			log.Println(err)
+			log.Fatal(err)
 		}
 		proxyURL = *p
 	}

--- a/main.go
+++ b/main.go
@@ -68,17 +68,23 @@ func getSourceMap(source string, headers []string, insecureTLS bool, proxyURL ur
 		req, err := http.NewRequest("GET", source, nil)
 		tr := &http.Transport{}
 
-		if proxyURL != (url.URL{}) {
-			tr.Proxy = http.ProxyURL(&proxyURL)
-		}
 		if insecureTLS {
 			tr := &http.Transport{
 				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 			}
+			if proxyURL != (url.URL{}) {
+				tr.Proxy = http.ProxyURL(&proxyURL)
+			}
+
+			tr.Proxy = http.ProxyURL(&proxyURL)
 			client = http.Client{
 				Transport: tr,
 			}
 		} else {
+
+			if proxyURL != (url.URL{}) {
+				tr.Proxy = http.ProxyURL(&proxyURL)
+			}
 			client = http.Client{
 				Transport: tr,
 			}


### PR DESCRIPTION
# What I changed

## Proxy Flag

Added `-proxy` which will handle Go default format proxies, for example I used `-proxy http://127.0.0.1:8080/ -insecure` for the default Burp settings.

### Changes made
I just modified the proxy handling in the HTTP transport for when the proxy flag is specified. This added a couple local variables and a few things. I suggest doing some additional testing.

## README change

Also made a little tweak to the README to actually have the correct arguments. Probably should have made this a different PR but I had already made my mistakes. Tell me if you want me to separate them.