### PR TITLE
Add -dir flag for batch processing a directory of .map files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ pacman -S sourcemapper
 ```text
 :~$ ./sourcemapper
 Usage of ./sourcemapper:
+  -dir string
+    	Directory of .map files to process recursively
   -header value
     	A header to send with the request, similar to curl's -H. Can be set multiple times, EG: "./sourcemapper --header "Cookie: session=bar" --header "Authorization: blerp"
   -help
@@ -39,14 +41,16 @@ Usage of ./sourcemapper:
   -insecure
     	Ignore invalid TLS certificates
   -jsurl string
-    	URL to JavaScript file - cannot be used with url
+    	URL to JavaScript file
   -output string
     	Source file output directory - REQUIRED
   -proxy string
     	Proxy URL
   -url string
-    	URL or path to the Sourcemap file - cannot be used with jsurl
+    	URL or path to the Sourcemap file
 ```
+
+Only one of `-url`, `-jsurl`, or `-dir` can be specified at a time.
 
 ## Extracting SourceMaps from .map URLs or local files
 
@@ -83,6 +87,22 @@ doi@asov:~/dhubsrc$ cd webpack\:/app/scripts/components/
 ```
 
 Sourcemapper will download or read the map file at `url`, and then spit the sources out into the directory defined by `output`. `url` can be either an URL, or a path to a map file on disk. Extracting a sourcemap to a file can get around sourcemaps configured with `sourceMappingURL=data:application/json;.... base64 blob...` by decoding the blob into a file, then passing the file path to sourcemapper. Alternatively, `data:` URL can be handled by directly parsing the JavaScript file as discussed in the following section.
+
+## Batch processing a directory of .map files
+
+Pass `-dir` instead of `-url` to recursively walk a directory and extract sources from every `.map` file found. Bad or empty sourcemaps are logged and skipped so one broken file doesn't stop the batch.
+
+```text
+$ ./sourcemapper -dir ./maps -output ./src
+[+] Found 12 .map files in ./maps
+[+] Processing: maps/app.js.map
+[+] Retrieving Sourcemap from maps/app.js.map...
+[+] Retrieved Sourcemap with version 3, containing 234 entries.
+...
+[+] Processing: maps/vendor.js.map
+...
+[+] Done
+```
 
 ## Extracting SourceMaps directly from JavaScript files
 

--- a/main.go
+++ b/main.go
@@ -32,6 +32,7 @@ type config struct {
 	outdir   string     // output directory
 	url      string     // sourcemap url
 	jsurl    string     // javascript url
+	dir      string     // directory of sourcemap files to process
 	proxy    string     // upstream proxy server
 	insecure bool       // skip tls verification
 	headers  headerList // additional user-supplied http headers
@@ -277,27 +278,80 @@ func cleanWindows(p string) string {
 	return m1.ReplaceAllString(p, "")
 }
 
+// processSourceMap extracts source files from a parsed sourcemap into outdir.
+func processSourceMap(sm sourceMap, outdir string) error {
+	log.Printf("[+] Retrieved Sourcemap with version %d, containing %d entries.\n", sm.Version, len(sm.Sources))
+
+	if len(sm.Sources) == 0 {
+		return errors.New("no sources found")
+	}
+
+	if len(sm.SourcesContent) == 0 {
+		return errors.New("no source content found")
+	}
+
+	if sm.Version != 3 {
+		log.Println("[!] Sourcemap is not version 3. This is untested!")
+	}
+
+	if _, err := os.Stat(outdir); os.IsNotExist(err) {
+		err = os.Mkdir(outdir, 0700)
+		if err != nil {
+			return err
+		}
+	}
+
+	for i, sourcePath := range sm.Sources {
+		sourcePath = "/" + sourcePath // path.Clean will ignore a leading '..', must be a '/..'
+		// If on windows, clean the sourcepath.
+		if runtime.GOOS == "windows" {
+			sourcePath = cleanWindows(sourcePath)
+		}
+
+		// Use filepath.Join. https://parsiya.net/blog/2019-03-09-path.join-considered-harmful/
+		scriptPath, scriptData := filepath.Join(outdir, filepath.Clean(sourcePath)), sm.SourcesContent[i]
+		err := writeFile(scriptPath, scriptData)
+		if err != nil {
+			log.Printf("Error writing %s file: %s", scriptPath, err)
+		}
+	}
+
+	return nil
+}
+
 func main() {
 	var proxyURL url.URL
 	var conf config
 	var err error
 
 	flag.StringVar(&conf.outdir, "output", "", "Source file output directory - REQUIRED")
-	flag.StringVar(&conf.url, "url", "", "URL or path to the Sourcemap file - cannot be used with jsurl")
-	flag.StringVar(&conf.jsurl, "jsurl", "", "URL to JavaScript file - cannot be used with url")
+	flag.StringVar(&conf.url, "url", "", "URL or path to the Sourcemap file")
+	flag.StringVar(&conf.jsurl, "jsurl", "", "URL to JavaScript file")
+	flag.StringVar(&conf.dir, "dir", "", "Directory of .map files to process recursively")
 	flag.StringVar(&conf.proxy, "proxy", "", "Proxy URL")
 	help := flag.Bool("help", false, "Show help")
 	flag.BoolVar(&conf.insecure, "insecure", false, "Ignore invalid TLS certificates")
 	flag.Var(&conf.headers, "header", "A header to send with the request, similar to curl's -H. Can be set multiple times, EG: \"./sourcemapper --header \"Cookie: session=bar\" --header \"Authorization: blerp\"")
 	flag.Parse()
 
-	if *help || (conf.url == "" && conf.jsurl == "") || conf.outdir == "" {
+	if *help || (conf.url == "" && conf.jsurl == "" && conf.dir == "") || conf.outdir == "" {
 		flag.Usage()
 		return
 	}
 
-	if conf.jsurl != "" && conf.url != "" {
-		log.Println("[!] Both -jsurl and -url supplied")
+	// Ensure only one input mode is specified
+	inputModes := 0
+	if conf.url != "" {
+		inputModes++
+	}
+	if conf.jsurl != "" {
+		inputModes++
+	}
+	if conf.dir != "" {
+		inputModes++
+	}
+	if inputModes > 1 {
+		log.Println("[!] Only one of -url, -jsurl, or -dir can be specified")
 		flag.Usage()
 		return
 	}
@@ -310,53 +364,53 @@ func main() {
 		proxyURL = *p
 	}
 
-	var sm sourceMap
-
-	// these need to just take the conf object
-	if conf.url != "" {
-		if sm, err = getSourceMap(conf.url, conf.headers, conf.insecure, proxyURL); err != nil {
-			log.Fatal(err)
-		}
-	} else if conf.jsurl != "" {
-		if sm, err = getSourceMapFromJS(conf.jsurl, conf.headers, conf.insecure, proxyURL); err != nil {
-			log.Fatal(err)
-		}
-	}
-
-	// everything below needs to go into its own function
-	log.Printf("[+] Retrieved Sourcemap with version %d, containing %d entries.\n", sm.Version, len(sm.Sources))
-
-	if len(sm.Sources) == 0 {
-		log.Fatal("No sources found.")
-	}
-
-	if len(sm.SourcesContent) == 0 {
-		log.Fatal("No source content found.")
-	}
-
-	if sm.Version != 3 {
-		log.Println("[!] Sourcemap is not version 3. This is untested!")
-	}
-
-	if _, err := os.Stat(conf.outdir); os.IsNotExist(err) {
-		err = os.Mkdir(conf.outdir, 0700)
+	if conf.dir != "" {
+		// Walk the directory and process all .map files
+		var mapFiles []string
+		err = filepath.Walk(conf.dir, func(path string, info os.FileInfo, err error) error {
+			if err != nil {
+				return err
+			}
+			if !info.IsDir() && strings.HasSuffix(strings.ToLower(info.Name()), ".map") {
+				mapFiles = append(mapFiles, path)
+			}
+			return nil
+		})
 		if err != nil {
 			log.Fatal(err)
 		}
-	}
+		if len(mapFiles) == 0 {
+			log.Fatalf("[!] No .map files found in %s", conf.dir)
+		}
+		log.Printf("[+] Found %d .map files in %s", len(mapFiles), conf.dir)
 
-	for i, sourcePath := range sm.Sources {
-		sourcePath = "/" + sourcePath // path.Clean will ignore a leading '..', must be a '/..'
-		// If on windows, clean the sourcepath.
-		if runtime.GOOS == "windows" {
-			sourcePath = cleanWindows(sourcePath)
+		for _, mapFile := range mapFiles {
+			log.Printf("[+] Processing: %s", mapFile)
+			sm, err := getSourceMap(mapFile, conf.headers, conf.insecure, proxyURL)
+			if err != nil {
+				log.Printf("[!] Error reading %s: %s, skipping.", mapFile, err)
+				continue
+			}
+			if err := processSourceMap(sm, conf.outdir); err != nil {
+				log.Printf("[!] Error processing %s: %s, skipping.", mapFile, err)
+				continue
+			}
+		}
+	} else {
+		var sm sourceMap
+
+		if conf.url != "" {
+			if sm, err = getSourceMap(conf.url, conf.headers, conf.insecure, proxyURL); err != nil {
+				log.Fatal(err)
+			}
+		} else if conf.jsurl != "" {
+			if sm, err = getSourceMapFromJS(conf.jsurl, conf.headers, conf.insecure, proxyURL); err != nil {
+				log.Fatal(err)
+			}
 		}
 
-		// Use filepath.Join. https://parsiya.net/blog/2019-03-09-path.join-considered-harmful/
-		scriptPath, scriptData := filepath.Join(conf.outdir, filepath.Clean(sourcePath)), sm.SourcesContent[i]
-		err := writeFile(scriptPath, scriptData)
-		if err != nil {
-			log.Printf("Error writing %s file: %s", scriptPath, err)
+		if err := processSourceMap(sm, conf.outdir); err != nil {
+			log.Fatal(err)
 		}
 	}
 


### PR DESCRIPTION
Adds a \`-dir\` flag that recursively walks a directory, finds all \`.map\` files, and extracts their sources into the output directory. Useful for offline analysis of sourcemaps already on disk (prior downloads, CI artifacts, etc).

### Changes
- Extract source extraction logic into \`processSourceMap()\` so it can be reused by both single-file and batch paths
- Add \`-dir\` flag with recursive \`.map\` file discovery via \`filepath.Walk\`
- Batch mode logs errors and continues on bad/empty files; single-file mode (\`-url\`/\`-jsurl\`) preserves the existing \`log.Fatal\` behavior
- Generalize the mutual-exclusion check on input flags to cover all three modes
- README updated with usage example